### PR TITLE
Fix a bug at parsing empty parentheses

### DIFF
--- a/lib/asciimath/parser.rb
+++ b/lib/asciimath/parser.rb
@@ -477,7 +477,7 @@ module AsciiMath
           t2 = tok.next_token
           case t2[:type]
             when :rparen, :lrparen
-              {:type => :paren, :e => e, :lparen => t1[:value], :rparen => t2[:value]}
+              {:type => :paren, :e => nil, :lparen => t1[:value], :rparen => t2[:value]}
             else
               tok.push_back(t2)
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -112,6 +112,11 @@ TEST_CASES = {
     {
         :mathml => '<math><mstyle mathvariant="bold"><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></mstyle><mo>+</mo><mstyle mathvariant="script"><mi>c</mi></mstyle><mo>=</mo><mstyle mathvariant="fraktur"><msup><mi>d</mi><mi>n</mi></msup></mstyle></math>',
         :html => 'Unsupported'
+    },
+    'max()' =>
+    {
+        :mathml => '<math><mo>max</mo><mrow><mo>(</mo><mo>)</mo></mrow></math>',
+        :html => '<span class="math-inline"><span class="math-row"><span class="math-operator">max</span><span class="math-row"><span class="math-brace">(</span><span class="math-brace">)</span></span></span></span>'
     }
 }
 


### PR DESCRIPTION
Hello, thank you for this great work.

Now I found a bug at parsing an expression including empty parentheses such as "max()" and fixed it.
```
$ asciimath "max()"
/Users/tsuchiya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/asciimath-1.0.5/lib/asciimath/parser.rb:480:in `parse_simple_expression': undefined local variable or method `e' for #<AsciiMath::Parser:0x007fc62c827e78> (NameError)
Did you mean?  e
	from /Users/tsuchiya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/asciimath-1.0.5/lib/asciimath/parser.rb:439:in `parse_expression'
	from /Users/tsuchiya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/asciimath-1.0.5/lib/asciimath/parser.rb:431:in `parse'
	from /Users/tsuchiya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/asciimath-1.0.5/lib/asciimath/parser.rb:558:in `parse'
	from /Users/tsuchiya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/asciimath-1.0.5/lib/asciimath/cli.rb:11:in `run'
	from /Users/tsuchiya/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/asciimath-1.0.5/bin/asciimath:4:in `<top (required)>'
	from /Users/tsuchiya/.rbenv/versions/2.3.1/bin/asciimath:23:in `load'
	from /Users/tsuchiya/.rbenv/versions/2.3.1/bin/asciimath:23:in `<main>'
```