### PR TITLE
Implemented LaTeX support for the 'color' binary operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -112,8 +112,8 @@ https://ctan.org/pkg/amsmath[`amsmath`] and `amssymb`, with a few exceptions:
  * `\twoheadrightarrowtail`
 
 The `\color` command is supported by the 
-https://www.ctan.org/pkg/xcolor[`xcolor`] color, included in most LaTeX 
-distributions. The other commands are supported by the 
+https://www.ctan.org/pkg/xcolor[`xcolor`] package, which is included in most 
+LaTeX distributions. The other commands are supported by the 
 https://ctan.org/pkg/stix[`stix`] package.
 
 ## Contributing

--- a/README.adoc
+++ b/README.adoc
@@ -105,14 +105,16 @@ There is currently no specific required font for this output, it simply selects 
 ## Notes on the LaTeX Output
 
 All LaTeX commands and environments used in the output are coverved by 
-https://ctan.org/pkg/amsmath[`amsmath`] and `amssymb`, with a couple of 
-exceptions:
+https://ctan.org/pkg/amsmath[`amsmath`] and `amssymb`, with a few exceptions:
 
+ * `\color`
  * `\mathscr`
  * `\twoheadrightarrowtail`
 
-Both this commands are supported by the https://ctan.org/pkg/stix[`stix`] 
-package.
+The `\color` command is supported by the 
+https://www.ctan.org/pkg/xcolor[`xcolor`] color, included in most LaTeX 
+distributions. The other commands are supported by the 
+https://ctan.org/pkg/stix[`stix`] package.
 
 ## Contributing
 

--- a/lib/asciimath/latex.rb
+++ b/lib/asciimath/latex.rb
@@ -72,9 +72,7 @@ module AsciiMath
       :partial => "\\del",
       :prime => ?',
       :tilde => "\\~",
-      :nbsp => "\\;",
-      :quad => "\\;\\;",
-      :qquad => "\\;\\;\\;\\;",
+      :nbsp => "\\:",
       :lceiling => "\\lceil",
       :rceiling => "\\rceil",
       :dstruck_captial_c => "\\mathbb{C}",
@@ -198,6 +196,17 @@ module AsciiMath
                 macro("sqrt", expression[:e1]) do
                   append(expression[:e2])
                 end
+            
+              when :color
+                curly do
+                  color do
+                    @latex << expression[:e1][:value]
+                  end
+
+                  @latex << " "
+                  append(expression[:e2])
+                end
+
               when Symbol
                 @latex << symbol(op)
 
@@ -208,6 +217,7 @@ module AsciiMath
                 curly do
                   append(expression[:e2])
                 end
+              
               when String
                 @latex << op
 
@@ -218,9 +228,11 @@ module AsciiMath
                 curly do
                   append(expression[:e2])
                 end
+              
               else
                 raise "Unsupported binary operation"
               end
+            
             when :matrix
               rows = expression[:rows]
               len = rows.length - 1

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -522,6 +522,7 @@ RSpec.shared_examples "AsciiMath Examples" do
           binary(:color, "blue", subsup("a", "b", "c"))
       ),
       :mathml => '<math><mstyle mathcolor="red"><mi>x</mi></mstyle><mstyle mathcolor="blue"><msubsup><mi>a</mi><mi>b</mi><mi>c</mi></msubsup></mstyle></math>',
+      :latex => '{\\color{red} x} {\\color{blue} a_b^c}',
   ))
 
   example('{ x\ : \ x in A ^^ x in B }', &should_generate(
@@ -531,6 +532,7 @@ RSpec.shared_examples "AsciiMath Examples" do
           :rbrace
       ),
       :mathml => '<math><mfenced open="{" close="}"><mrow><mi>x</mi><mo>&#xA0;</mo><mi>:</mi><mo>&#xA0;</mo><mi>x</mi><mo>&#x2208;</mo><mi>A</mi><mo>&#x2227;</mo><mi>x</mi><mo>&#x2208;</mo><mi>B</mi></mrow></mfenced></math>',
+      :latex => '\\left \\{ x \\: : \\: x \\in A \\wedge x \\in B \\right \\}',
   ))
 
   version = RUBY_VERSION.split('.').map { |s| s.to_i }


### PR DESCRIPTION
Followup to #22 . Also corrected the rendering of '\ ', 'quad' and 'qquad'.