### PR TITLE
Add proper support for '%' and '!' symbols

### DIFF
--- a/lib/asciimath/latex.rb
+++ b/lib/asciimath/latex.rb
@@ -45,6 +45,8 @@ module AsciiMath
       :rvert => "\\rVert",
       :vbar => ?|,
       nil => ?.,
+      :percent => "\\%",
+      :exclamation => ?!,
       :integral => "\\int",
       :dx => "dx",
       :dy => "dy",

--- a/lib/asciimath/markup.rb
+++ b/lib/asciimath/markup.rb
@@ -83,6 +83,8 @@ module AsciiMath
       b.add(:parallel, "\u2225", :lrparen)
 
       # Miscellaneous symbols
+      b.add(:percent, '%', :operator)
+      b.add(:exclamation, '!', :operator)
       b.add(:integral, "\u222B", :operator)
       b.add(:dx, 'dx', :identifier)
       b.add(:dy, 'dy', :identifier)

--- a/lib/asciimath/parser.rb
+++ b/lib/asciimath/parser.rb
@@ -303,6 +303,8 @@ module AsciiMath
       b.add(':}', nil, :rparen)
 
       # Miscellaneous symbols
+      b.add('%', :percent, :symbol)
+      b.add('!', :exclamation, :symbol)
       b.add('int', :integral, :symbol)
       b.add('dx', :dx, :symbol)
       b.add('dy', :dy, :symbol)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -587,6 +587,13 @@ RSpec.shared_examples 'AsciiMath Examples' do
       :mathml => '<math><mover accent="true"><mi></mi><mo>^</mo></mover></math>'
   ))
 
+  example('40% * 3!', &should_generate(
+      :ast => seq('40', symbol('%'), symbol('*'), '3', symbol('!')),
+      :mathml => '<math><mn>40</mn><mo>%</mo><mo>&#x22C5;</mo><mn>3</mn><mo>!</mo></math>',
+      :html => '<span class="math-inline"><span class="math-number">40</span><span class="math-operator">%</span><span class="math-operator">&#x22C5;</span><span class="math-number">3</span><span class="math-operator">!</span></span>',
+      :latex => '40 \% \cdot 3 !'
+  ))
+
   version = RUBY_VERSION.split('.').map { |s| s.to_i }
 
   if version[0] > 1 || version[1] > 8


### PR DESCRIPTION
Looks like we did it simultaneously. This addresses the issue #58, which has been just fixed in 17b3711ad848ccfd179c441402626ca2c8adf452. Nevertheless, I'm creating this pull request just in case it contains something worth adding to the master.

----

- Recognize them as symbols
- Render them properly as <mo> when converting to MathML
- Render them properly when converting to LaTeX math
- Render them properly when converting to HTML math