### PR TITLE
LaTeX fix ellipsis translation

### DIFF
--- a/AST.adoc
+++ b/AST.adoc
@@ -257,8 +257,8 @@ Empty matrix cells are represented as `AsciiMath::AST::Empty`.
 |++oo++ |:infty |++∞++ (https://codepoints.net/U+221E[U+221E]) |++\infty++
 |++infty++ |:infty |++∞++ (https://codepoints.net/U+221E[U+221E]) |++\infty++
 |++aleph++ |:aleph |++ℵ++ (https://codepoints.net/U+2135[U+2135]) |++\aleph++
-|++...++ |:ellipsis |++…++ (https://codepoints.net/U+2026[U+2026]) |++\ellipsis++
-|++ldots++ |:ellipsis |++…++ (https://codepoints.net/U+2026[U+2026]) |++\ellipsis++
+|++...++ |:ellipsis |++…++ (https://codepoints.net/U+2026[U+2026]) |++\ldots++
+|++ldots++ |:ellipsis |++…++ (https://codepoints.net/U+2026[U+2026]) |++\ldots++
 |++:.++ |:therefore |++∴++ (https://codepoints.net/U+2234[U+2234]) |++\therefore++
 |++therefore++ |:therefore |++∴++ (https://codepoints.net/U+2234[U+2234]) |++\therefore++
 |++:'++ |:because |++∵++ (https://codepoints.net/U+2235[U+2235]) |++\because++

--- a/lib/asciimath/latex.rb
+++ b/lib/asciimath/latex.rb
@@ -85,6 +85,7 @@ module AsciiMath
       :f => "f",
       :g => "g",
       :to => "\\rightarrow",
+      :ellipsis => "\\ldots",
       :bold => "\\mathbf",
       :double_struck => "\\mathbb",
       :italic => "\\mathit",

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -624,6 +624,13 @@ RSpec.shared_examples 'AsciiMath Examples' do
     :mathml => '<math><mo>&#x223C;</mo><mi>a</mi><mo>&#x226A;</mo><mi>b</mi><mo>&#x226B;</mo><mo>&#x2213;</mo><mi>c</mi></math>'
     ))
 
+  example('a+b+...+c', &should_generate(
+    :ast => seq('a', symbol('+'), 'b', symbol('+'), symbol('...'), symbol('+'), 'c'),
+    :latex => 'a + b + \ldots + c',
+    :mathml => '<math><mi>a</mi><mo>+</mo><mi>b</mi><mo>+</mo><mo>&#x2026;</mo><mo>+</mo><mi>c</mi></math>'
+    ))
+    
+
   version = RUBY_VERSION.split('.').map { |s| s.to_i }
 
   if version[0] > 1 || version[1] > 8


### PR DESCRIPTION
Hi,

I noticed that the `...` symbol was not being properly handled: it was being translated to `\ellipsis` (which is not valid LaTeX), instead of `\ldots` (which is the correct translation as per the [AsciiMath syntax](http://asciimath.org/#syntax)).