### PR TITLE
Fix compatibility with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ jobs:
       matrix:
         ruby: [jruby, 2.3, 2.4, 2.5, 2.6, 2.7]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        rubyopt: [""]
+        include:
+          - ruby: 2.7
+            os: ubuntu-latest
+            rubyopt: "--enable-frozen-string-literal --debug-frozen-string-literal"
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -17,4 +23,4 @@ jobs:
       - name: Build
         run: bundle install --jobs 4 --retry 3
       - name: Test
-        run: bundle exec rake test
+        run: bundle exec rake test RUBYOPT="${{ matrix.rubyopt }}"

--- a/lib/asciimath/html.rb
+++ b/lib/asciimath/html.rb
@@ -8,7 +8,7 @@ module AsciiMath
       @prefix = opts[:prefifx] || ''
       @inline = opts[:inline]
       @escape_non_ascii = opts.fetch(:escape_non_ascii, true)
-      @html = ''
+      @html = ''.dup
     end
 
     def to_s

--- a/lib/asciimath/latex.rb
+++ b/lib/asciimath/latex.rb
@@ -5,7 +5,7 @@ module AsciiMath
     attr_reader :symbol_table
 
     def initialize(symbol_table = nil)
-      @latex = ''
+      @latex = ''.dup
       @symbol_table = symbol_table.nil? ? DEFAULT_DISPLAY_SYMBOL_TABLE : symbol_table
     end
 

--- a/lib/asciimath/mathml.rb
+++ b/lib/asciimath/mathml.rb
@@ -7,7 +7,7 @@ module AsciiMath
     def initialize(opts = {})
       super(opts[:symbol_table] || ::AsciiMath::MarkupBuilder.default_display_symbol_table(fix_phi: opts.fetch(:fix_phi, true)))
       @prefix = opts[:prefix] || ''
-      @mathml = ''
+      @mathml = ''.dup
       if opts[:msword]
         @row_mode = :force
         @fence_mode = :fenced

--- a/lib/asciimath/parser.rb
+++ b/lib/asciimath/parser.rb
@@ -753,7 +753,7 @@ module AsciiMath
     end
 
     def convert_to_color(color_expression)
-      s = ""
+      s = "".dup
       append_color_text(s, color_expression)
 
       case s


### PR DESCRIPTION
Since Ruby 2.4, Ruby can be launched with `--enable-frozen-string-literal`.